### PR TITLE
Break out credentialSubject negative tests into separate tests.

### DIFF
--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -159,7 +159,7 @@ describe('Issue Credential - Data Integrity', function() {
         shouldThrowInvalidInput({result, error});
       });
       for(const [title, invalidSubject] of invalidCredentialSubjectTypes) {
-        it(`"credential.credentialSubject" MUST NOT be ${title}`,
+        it(`issuer errors when "credential.credentialSubject" is ${title}`,
           async function() {
             this.test.cell = {
               columnId: name,

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -1,7 +1,11 @@
 /*!
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {createISOTimeStamp, createRequestBody} from './mock.data.js';
+import {
+  createISOTimeStamp,
+  createRequestBody,
+  invalidCredentialSubjectTypes
+} from './mock.data.js';
 import {
   shouldBeIssuedVc,
   shouldReturnResult,
@@ -154,24 +158,22 @@ describe('Issue Credential - Data Integrity', function() {
         const {result, error} = await issuer.post({json: body});
         shouldThrowInvalidInput({result, error});
       });
-      it('"credential.credentialSubject" MUST be an object', async function() {
-        this.test.cell = {
-          columnId: name,
-          rowId: this.test.title
-        };
-        const body = createRequestBody({issuer});
-        const invalidCredentialSubjectTypes =
-          [null, true, 4, [], 'did:example:1234'];
-        for(const invalidCredentialSubjectType of
-          invalidCredentialSubjectTypes) {
-          body.credential.credentialSubject = invalidCredentialSubjectType;
-          const {result, error} = await issuer.post({json: {...body}});
-          shouldThrowInvalidInput({result, error});
-        }
-      });
-      // this test is probably redudant as the vc-data-model spec
+      for(const [title, invalidSubject] of invalidCredentialSubjectTypes) {
+        it(`"credential.credentialSubject" MUST NOT be ${title}`,
+          async function() {
+            this.test.cell = {
+              columnId: name,
+              rowId: this.test.title
+            };
+            const body = createRequestBody({issuer});
+            body.credential.credentialSubject = invalidSubject;
+            const {result, error} = await issuer.post({json: {...body}});
+            shouldThrowInvalidInput({result, error});
+          });
+      }
+      // this test is probably redundant as the vc-data-model spec
       // requires issuanceDate
-      it.skip('credential MAY have property "issuanceDate"', async function() {
+      it.skip('credential MUST have property "issuanceDate"', async function() {
         this.test.cell = {
           columnId: name,
           rowId: this.test.title

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -31,3 +31,12 @@ export const createRequestBody = ({issuer, vc = validVc}) => {
 export function createISOTimeStamp(timeMs = Date.now()) {
   return new Date(timeMs).toISOString().replace(/\.\d+Z$/, 'Z');
 }
+
+export const invalidCredentialSubjectTypes = new Map([
+  ['null', null],
+  ['a boolean', true],
+  ['a number', 4],
+  ['an empty list', []],
+  ['a string', 'a string']
+]);
+

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -36,7 +36,7 @@ export const invalidCredentialSubjectTypes = new Map([
   ['null', null],
   ['a boolean', true],
   ['a number', 4],
-  ['an empty list', []],
+  ['an empty Array', []],
   ['a string', 'a string']
 ]);
 


### PR DESCRIPTION
This takes a single test for `credentialSubject MUST BE an object` and turns it into 5 negative tests:

1. "credential.credentialSubject" MUST NOT be null
2. "credential.credentialSubject" MUST NOT be a boolean
3. "credential.credentialSubject" MUST NOT be a number
4. "credential.credentialSubject" MUST NOT be an empty list
5. "credential.credentialSubject" MUST NOT be a string

This should help to resolve confusion around what is being tested with the credentialSubject test.

https://github.com/w3c-ccg/vc-api-issuer-test-suite/issues/32