### PR TITLE
Expand issuer tests

### DIFF
--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -136,16 +136,17 @@ describe('Issue Credential - Data Integrity', function() {
         shouldThrowInvalidInput({result, error});
       });
       for(const [title, invalidIssuer] of invalidIssuerTypes) {
-        it(`"credential.issuer" MUST NOT be ${title}`, async function() {
-          this.test.cell = {
-            columnId: name,
-            rowId: this.test.title
-          };
-          const body = createRequestBody({issuer});
-          body.credential.issuer = invalidIssuer;
-          const {result, error} = await issuer.post({json: {...body}});
-          shouldThrowInvalidInput({result, error});
-        });
+        it(`issuer errors when "credential.issuer" is ${title}`,
+          async function() {
+            this.test.cell = {
+              columnId: name,
+              rowId: this.test.title
+            };
+            const body = createRequestBody({issuer});
+            body.credential.issuer = invalidIssuer;
+            const {result, error} = await issuer.post({json: {...body}});
+            shouldThrowInvalidInput({result, error});
+          });
       }
       it('"credential.issuer" MAY be a string', async function() {
         this.test.cell = {

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -147,6 +147,32 @@ describe('Issue Credential - Data Integrity', function() {
           shouldThrowInvalidInput({result, error});
         });
       }
+      it('"credential.issuer" MAY be a string', async function() {
+        this.test.cell = {
+          columnId: name,
+          rowId: this.test.title
+        };
+        const body = createRequestBody({issuer});
+        const {result, data: issuedVc, error} = await issuer.post({json: body});
+        shouldReturnResult({result, error});
+        should.exist(issuedVc, 'Expected result to have data.');
+        result.status.should.equal(201, 'Expected statusCode 201.');
+        shouldBeIssuedVc({issuedVc});
+      });
+      it('"credential.issuer" MAY be an object', async function() {
+        this.test.cell = {
+          columnId: name,
+          rowId: this.test.title
+        };
+        const body = createRequestBody({issuer});
+        // set the issuer to an object with the id equal to the issuer
+        body.credential.issuer = {id: body.credential.issuer};
+        const {result, data: issuedVc, error} = await issuer.post({json: body});
+        shouldReturnResult({result, error});
+        should.exist(issuedVc, 'Expected result to have data.');
+        result.status.should.equal(201, 'Expected statusCode 201.');
+        shouldBeIssuedVc({issuedVc});
+      });
       it('credential MUST have property "credentialSubject"', async function() {
         this.test.cell = {
           columnId: name,

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -1,7 +1,11 @@
 /*!
  * Copyright (c) 2022 Digital Bazaar, Inc. All rights reserved.
  */
-import {createISOTimeStamp, createRequestBody} from './mock.data.js';
+import {
+  createISOTimeStamp,
+  createRequestBody,
+  invalidIssuerTypes
+} from './mock.data.js';
 import {
   shouldBeIssuedVc,
   shouldReturnResult,
@@ -131,19 +135,18 @@ describe('Issue Credential - Data Integrity', function() {
         const {result, error} = await issuer.post({json: body});
         shouldThrowInvalidInput({result, error});
       });
-      it('"credential.issuer" MUST be a string or an object', async function() {
-        this.test.cell = {
-          columnId: name,
-          rowId: this.test.title
-        };
-        const body = createRequestBody({issuer});
-        const invalidIssuerTypes = [null, true, 4, []];
-        for(const invalidIssuerType of invalidIssuerTypes) {
-          body.credential.issuer = invalidIssuerType;
+      for(const [title, invalidIssuer] of invalidIssuerTypes) {
+        it(`"credential.issuer" MUST NOT be ${title}`, async function() {
+          this.test.cell = {
+            columnId: name,
+            rowId: this.test.title
+          };
+          const body = createRequestBody({issuer});
+          body.credential.issuer = invalidIssuer;
           const {result, error} = await issuer.post({json: {...body}});
           shouldThrowInvalidInput({result, error});
-        }
-      });
+        });
+      }
       it('credential MUST have property "credentialSubject"', async function() {
         this.test.cell = {
           columnId: name,

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -36,5 +36,5 @@ export const invalidIssuerTypes = new Map([
   ['null', null],
   ['a boolean', true],
   ['a number', 4],
-  ['an empty list', []]
+  ['an empty Array', []]
 ]);

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -31,3 +31,10 @@ export const createRequestBody = ({issuer, vc = validVc}) => {
 export function createISOTimeStamp(timeMs = Date.now()) {
   return new Date(timeMs).toISOString().replace(/\.\d+Z$/, 'Z');
 }
+
+export const invalidIssuerTypes = new Map([
+  ['null', null],
+  ['a boolean', true],
+  ['a number', 4],
+  ['an empty list', []]
+]);


### PR DESCRIPTION
Takes a test which tested multiple negative states of the issuer and turns it into multiple stand alone negative tests and 2 new positive tests:

1. "credential.issuer" MUST NOT be null
2. "credential.issuer" MUST NOT be a boolean
3. "credential.issuer" MUST NOT be a number
4. "credential.issuer" MUST NOT be an empty list
5. "credential.issuer" MAY be a string
6. "credential.issuer" MAY be an object

Addresses: https://github.com/w3c-ccg/vc-api-issuer-test-suite/issues/32