### PR TITLE
Expand @context tests.

### DIFF
--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -121,7 +121,7 @@ describe('Issue Credential - Data Integrity', function() {
           shouldBeIssuedVc({issuedVc});
         });
       for(const [title, invalidContext] of invalidContextTypes) {
-        it(`credential "@context" items MUST NOT be ${title}.`,
+        it(`issuer errors when credential "@context" items are ${title}.`,
           async function() {
             this.test.cell = {
               columnId: name,

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -121,7 +121,7 @@ describe('Issue Credential - Data Integrity', function() {
           shouldBeIssuedVc({issuedVc});
         });
       for(const [title, invalidContext] of invalidContextTypes) {
-        it(`credential "@context" items MUST NOT be ${title}`,
+        it(`credential "@context" items MUST NOT be ${title}.`,
           async function() {
             this.test.cell = {
               columnId: name,

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -31,3 +31,10 @@ export const createRequestBody = ({issuer, vc = validVc}) => {
 export function createISOTimeStamp(timeMs = Date.now()) {
   return new Date(timeMs).toISOString().replace(/\.\d+Z$/, 'Z');
 }
+
+export const invalidContextTypes = new Map([
+  ['empty', []],
+  ['a number', [4]],
+  ['a boolean', [false]],
+  ['null', [null]]
+]);


### PR DESCRIPTION
Expands the context tests with these new tests:

1. credential `@context` first item MUST be credentials context URI.
2. credential `@context` subsequent items MAY be context objects.
3. credential `@context` items MUST NOT be empty
4. credential `@context` items MUST NOT be a number
5. credential `@context` items MUST NOT be a boolean
6. credential `@context` items MUST NOT be null
