### PR TITLE
Expand tests for VC types.

### DIFF
--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -125,16 +125,17 @@ describe('Issue Credential - Data Integrity', function() {
         shouldBeIssuedVc({issuedVc});
       });
       for(const [title, invalidType] of invalidCredentialTypes) {
-        it(`"credential.type" items MUST NOT be ${title}.`, async function() {
-          this.test.cell = {
-            columnId: name,
-            rowId: this.test.title
-          };
-          const body = createRequestBody({issuer});
-          body.credential.type = invalidType;
-          const {result, error} = await issuer.post({json: {...body}});
-          shouldThrowInvalidInput({result, error});
-        });
+        it(`issuer errors when "credential.type" items are ${title}.`,
+          async function() {
+            this.test.cell = {
+              columnId: name,
+              rowId: this.test.title
+            };
+            const body = createRequestBody({issuer});
+            body.credential.type = invalidType;
+            const {result, error} = await issuer.post({json: {...body}});
+            shouldThrowInvalidInput({result, error});
+          });
       }
       it('credential MUST have property "issuer"', async function() {
         this.test.cell = {

--- a/tests/mock.data.js
+++ b/tests/mock.data.js
@@ -31,3 +31,10 @@ export const createRequestBody = ({issuer, vc = validVc}) => {
 export function createISOTimeStamp(timeMs = Date.now()) {
   return new Date(timeMs).toISOString().replace(/\.\d+Z$/, 'Z');
 }
+
+export const invalidCredentialTypes = new Map([
+  ['null', [null]],
+  ['a boolean', [true]],
+  ['a number', [4]],
+  ['empty', []]
+]);


### PR DESCRIPTION
Expands the `credential.type` tests to include:

"credential.type" items MUST be strings.
"credential.type" items MUST NOT be null.
"credential.type" items MUST NOT be a boolean. 
"credential.type" items MUST NOT be a number.
"credential.type" items MUST NOT be empty.

