### PR TITLE
Unpin node version so  gh actions will run on the latest version of node 20

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20.8.0]
+        node-version: [20.x]
     steps:
     - uses: actions/checkout@v4
     - name: Use Node.js ${{ matrix.node-version }}
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        node-version: [20.8.0]
+        node-version: [20.x]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
     "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
   },
   "devDependencies": {
-    "eslint": "^8.19.0",
-    "eslint-config-digitalbazaar": "^4.0.1",
-    "eslint-plugin-jsdoc": "^39.3.3",
-    "eslint-plugin-unicorn": "^43.0.0"
+    "eslint": "^8.54.0",
+    "eslint-config-digitalbazaar": "^5.0.1",
+    "eslint-plugin-jsdoc": "^46.9.0",
+    "eslint-plugin-unicorn": "^49.0.0"
   }
 }


### PR DESCRIPTION
- Additionally, updates eslint dev deps to latest.