### PR TITLE
Rename `vc-api-test-suite-implementations` to `vc-test-suite-implementations`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # w3c-ccg/vc-api-issuer-test-suite ChangeLog
 
+## 1.1.0 - 2023-12-14
+
+### Changed
+- Updated `vc-api-test-suite-implementations` package name to
+  `vc-test-suite-implementations`.
+  
 ## 1.0.0 - 2023-11-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # vc-api-issuer-test-suite
+
 Test Suite for Issuers that implement the VC HTTP API
 
 ## Table of Contents
@@ -27,6 +28,12 @@ npm test
 
 
 ## Implementation
-To add your implementation to this test suite see the [README here.](https://github.com/w3c-ccg/vc-api-test-suite-implementations)
-Add the tag `vc-api` to the issuers and verifiers you want tested. To run the tests, some implementations require client secrets
-that can be passed as env variables to the test script. To see which ones require client secrets, you can check the [vc-api-test-suite-implementations](https://github.com/w3c-ccg/vc-api-test-suite-implementations) library.
+
+To add your implementation to this test suite see the
+`w3c-ccg/vc-test-suite-implementations` [README](https://github.com/w3c-ccg/vc-test-suite-implementations/blob/main/README.md). Add the tag `vc-api` to the issuers you want
+to run the tests against.
+
+Note: To run the tests, some implementations require client secrets that can be
+passed as env variables to the test script. To see which ones require client
+secrets, you can check configs in the `w3c-ccg/vc-test-suite-implementations`
+repo.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "klona": "^2.0.5",
     "mocha": "^10.0.0",
     "uuid": "^8.3.2",
-    "vc-api-test-suite-implementations": "github:w3c-ccg/vc-api-test-suite-implementations"
+    "vc-test-suite-implementations": "github:w3c-ccg/vc-test-suite-implementations#rename-package"
   },
   "devDependencies": {
     "eslint": "^8.54.0",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "klona": "^2.0.5",
     "mocha": "^10.0.0",
     "uuid": "^8.3.2",
-    "vc-test-suite-implementations": "github:w3c-ccg/vc-test-suite-implementations#rename-package"
+    "vc-test-suite-implementations": "github:w3c-ccg/vc-test-suite-implementations"
   },
   "devDependencies": {
     "eslint": "^8.54.0",

--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -8,7 +8,7 @@ import {
   shouldThrowInvalidInput
 } from './assertions.js';
 import chai from 'chai';
-import {filterByTag} from 'vc-api-test-suite-implementations';
+import {filterByTag} from 'vc-test-suite-implementations';
 
 const should = chai.should();
 const tag = 'vc-api';

--- a/tests/11-issuer-jwt.js
+++ b/tests/11-issuer-jwt.js
@@ -4,7 +4,7 @@
 import {shouldBeIssuedVc, shouldThrowInvalidInput} from './assertions.js';
 import chai from 'chai';
 import {createRequestBody} from './mock.data.js';
-import {filterByTag} from 'vc-api-test-suite-implementations';
+import {filterByTag} from 'vc-test-suite-implementations';
 
 const should = chai.should();
 


### PR DESCRIPTION
~Related to https://github.com/w3c-ccg/vc-api-test-suite-implementations/pull/92, must be merged only once the PR updating the package name gets merged.~ PR has been merged