### PR TITLE
Update 'array item' tests to set arrays for the tested properties

### DIFF
--- a/tests/10-issuer.js
+++ b/tests/10-issuer.js
@@ -82,7 +82,7 @@ describe('Issue Credential - Data Integrity', function() {
         const body = createRequestBody({issuer});
         const invalidContextTypes = [{foo: true}, 4, false, null];
         for(const invalidContextType of invalidContextTypes) {
-          body.credential['@context'] = invalidContextType;
+          body.credential['@context'] = [invalidContextType];
           const {result, error} = await issuer.post({json: {...body}});
           shouldThrowInvalidInput({result, error});
         }
@@ -115,7 +115,7 @@ describe('Issue Credential - Data Integrity', function() {
         const body = createRequestBody({issuer});
         const invalidCredentialTypes = [null, true, 4, []];
         for(const invalidCredentialType of invalidCredentialTypes) {
-          body.credential.type = invalidCredentialType;
+          body.credential.type = [invalidCredentialType];
           const {result, error} = await issuer.post({json: {...body}});
           shouldThrowInvalidInput({result, error});
         }

--- a/tests/11-issuer-jwt.js
+++ b/tests/11-issuer-jwt.js
@@ -79,7 +79,7 @@ describe('Issue Credential - JWT', function() {
         const body = createRequestBody({issuer});
         const invalidContextTypes = [{foo: true}, 4, false, null];
         for(const invalidContextType of invalidContextTypes) {
-          body.credential['@context'] = invalidContextType;
+          body.credential['@context'] = [invalidContextType];
           const {result, error} = await issuer.post({json: {...body}});
           shouldThrowInvalidInput({result, error});
         }
@@ -112,7 +112,7 @@ describe('Issue Credential - JWT', function() {
         const body = createRequestBody({issuer});
         const invalidCredentialTypes = [null, true, 4, []];
         for(const invalidCredentialType of invalidCredentialTypes) {
-          body.credential.type = invalidCredentialType;
+          body.credential.type = [invalidCredentialType];
           const {result, error} = await issuer.post({json: {...body}});
           shouldThrowInvalidInput({result, error});
         }


### PR DESCRIPTION
This PR changes the following two tests in 10-issuer.js:

'"credential.type" items MUST be strings'

and

'credential "@context" items MUST be strings.'

so that they now set arrays for the properties to be tested.

The two tests both appear to be intended to test cases where the given property ('type' and '@context') is set to an array containing items that aren't strings, but I think the items aren't actually added into an array before setting.

For example, one of the requests that is sent for the 'type' test looks like so:

```
{
    "@context": [
        "https://www.w3.org/2018/credentials/v1"
    ],
    "type": 4,
    "credentialSubject": {
        "id": "did:key:z6MkhTNL7i2etLerDK8Acz5t528giE5KA4p75T6ka1E1D74r"
    },
    "issuanceDate": "2024-10-23T18:34:09Z",
    "id": "urn:uuid:f1ebf317-836a-46af-bf96-1eddab9cad81",
    "issuer": "did:key:z6MknNQD1WHLGGraFi6zcbGevuAgkVfdyCdtZnQTGWVVvR5Q"
}
```

whereas I think it was meant to be sent like so (which it now does with the committed fix):

```
{
    "@context": [
        "https://www.w3.org/2018/credentials/v1"
    ],
    "type": [
        4
    ],
    "credentialSubject": {
        "id": "did:key:z6MkhTNL7i2etLerDK8Acz5t528giE5KA4p75T6ka1E1D74r"
    },
    "issuanceDate": "2024-10-23T18:40:29Z",
    "id": "urn:uuid:55e11d97-8437-40b9-8381-cb62c350c231",
    "issuer": "did:key:z6MknNQD1WHLGGraFi6zcbGevuAgkVfdyCdtZnQTGWVVvR5Q"
}
```


